### PR TITLE
feat: add option for bold/italic formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ modicator.setup({
     -- Options in `overrides` will apply to every mode, regardless of
     -- settings in the `modes` table. Useful if you want to apply a style
     -- to every mode.
-    overrides = {
+    defaults = {
       bold = false,
-      bold = false
+      italic = false
     },
     modes = {
       ['n'] = {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ use { 'melkster/modicator.nvim',
 }
 ```
 
+Or with [lazy.nvim](https://github.com/folke/lazy.nvim/):
+```lua
+return {
+  'mawkler/modicator.nvim',
+  dependencies = 'onedark.nvim' -- Add your colorscheme plugin here,
+  init = function()
+    vim.o.cursorline = true
+    vim.o.number = true
+    vim.o.termguicolors = true
+  end,
+  config = function()
+    require('modicator').setup({
+      -- ...
+    })
+  end,
+}
+```
+
 ## Configuration
 
 Use `highlights.modes` to set the color for each mode, and pass it to `.setup()`. The key for each color is the output `mode()` for that mode. Check out `:help mode()` for more information.
@@ -50,28 +68,59 @@ local modicator = require('modicator')
 modicator.setup({
   show_warnings = true, -- Show warning if any required option is missing
   highlights = {
-    modes = {
-      ['i'] = modicator.get_highlight_fg('Question'),
-      ['v'] = modicator.get_highlight_fg('Type'),
-      ['V'] = modicator.get_highlight_fg('Type'),
-      [''] = modicator.get_highlight_fg('Type'),
-      ['s'] = modicator.get_highlight_fg('Keyword'),
-      ['S'] = modicator.get_highlight_fg('Keyword'),
-      ['R'] = modicator.get_highlight_fg('Title'),
-      ['c'] = modicator.get_highlight_fg('Constant'),
+    -- Options in `overrides` will apply to every mode, regardless of
+    -- settings in the `modes` table. Useful if you want to apply a style
+    -- to every mode.
+    overrides = {
+      bold = false,
+      bold = false
     },
-  },
-  formats = {
     modes = {
-      ['n']  = { bold = false, italic = false },
-      ['i']  = { bold = false, italic = false },
-      ['v']  = { bold = false, italic = false },
-      ['V']  = { bold = false, italic = false },
-      [''] = { bold = false, italic = false },
-      ['s']  = { bold = false, italic = false },
-      ['S']  = { bold = false, italic = false },
-      ['R']  = { bold = false, italic = false },
-      ['c']  = { bold = false, italic = false },
+      ['n'] = {
+        color = M.get_highlight_fg('CursorLineNr'),
+        bold = false,
+        italic = false,
+      },
+      ['i']  = {
+        color = M.get_highlight_fg('Question'),
+        bold = false,
+        italic = false,
+      },
+      ['v']  = {
+        color = M.get_highlight_fg('Type'),
+        bold = false,
+        italic = false,
+      },
+      ['V']  = {
+        color = M.get_highlight_fg('Type'),
+        bold = false,
+        italic = false,
+      },
+      ['�'] = {
+        color = M.get_highlight_fg('Type'),
+        bold = false,
+        italic = false,
+      },
+      ['s']  = {
+        color = M.get_highlight_fg('Keyword'),
+        bold = false,
+        italic = false,
+      },
+      ['S']  = {
+        color = M.get_highlight_fg('Keyword'),
+        bold = false,
+        italic = false,
+      },
+      ['R']  = {
+        color = M.get_highlight_fg('Title'),
+        bold = false,
+        italic = false,
+      },
+      ['c']  = {
+        color = M.get_highlight_fg('Constant'),
+        bold = false,
+        italic = false,
+      },
     },
   },
 })

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use { 'melkster/modicator.nvim',
 
 Use `highlights.modes` to set the color for each mode, and pass it to `.setup()`. The key for each color is the output `mode()` for that mode. Check out `:help mode()` for more information.
 
-For normal mode, Modicator uses the `CursorLineNr`'s `fg` highlight. The other highligt keys of `CursorLineNr` (`bg`, `gui`, `bold`, etc.) are preserved when you switch to other modes. Modicator only modifies `CursorLineNr`'s `fg` color.
+For normal mode, Modicator uses the `CursorLineNr`'s `fg` highlight. The other highlight keys of `CursorLineNr` (`bg`, `gui`, `bold`, etc.) are preserved when you switch to other modes. Modicator only modifies `CursorLineNr`'s `fg` color.
 
 **Default configuration:**
 

--- a/README.md
+++ b/README.md
@@ -61,5 +61,18 @@ modicator.setup({
       ['c'] = modicator.get_highlight_fg('Constant'),
     },
   },
+  formats = {
+    modes = {
+      ['n']  = { bold = false, italic = false },
+      ['i']  = { bold = false, italic = false },
+      ['v']  = { bold = false, italic = false },
+      ['V']  = { bold = false, italic = false },
+      [''] = { bold = false, italic = false },
+      ['s']  = { bold = false, italic = false },
+      ['S']  = { bold = false, italic = false },
+      ['R']  = { bold = false, italic = false },
+      ['c']  = { bold = false, italic = false },
+    },
+  },
 })
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ local modicator = require('modicator')
 modicator.setup({
   show_warnings = true, -- Show warning if any required option is missing
   highlights = {
-    -- Options in `overrides` will apply to every mode, regardless of
+    -- Options in `defaults` will apply to every mode, regardless of
     -- settings in the `modes` table. Useful if you want to apply a style
     -- to every mode.
     defaults = {

--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -14,7 +14,7 @@ local options = {
   highlights = {
     overrides = {
       bold = false,
-      bold = false
+      italic = false
     },
     modes = {
       ['n'] = {

--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -12,44 +12,71 @@ end
 local options = {
   show_warnings = true, -- Show warning if any required option is missing
   highlights = {
-    modes = {
-      ['n']  = M.get_highlight_fg('CursorLineNr'),
-      ['i']  = M.get_highlight_fg('Question'),
-      ['v']  = M.get_highlight_fg('Type'),
-      ['V']  = M.get_highlight_fg('Type'),
-      [''] = M.get_highlight_fg('Type'),
-      ['s']  = M.get_highlight_fg('Keyword'),
-      ['S']  = M.get_highlight_fg('Keyword'),
-      ['R']  = M.get_highlight_fg('Title'),
-      ['c']  = M.get_highlight_fg('Constant'),
+    overrides = {
+      bold = false,
+      bold = false
     },
-  },
-  formats = {
     modes = {
-      ['n']  = { bold = false, italic = false },
-      ['i']  = { bold = false, italic = false },
-      ['v']  = { bold = false, italic = false },
-      ['V']  = { bold = false, italic = false },
-      [''] = { bold = false, italic = false },
-      ['s']  = { bold = false, italic = false },
-      ['S']  = { bold = false, italic = false },
-      ['R']  = { bold = false, italic = false },
-      ['c']  = { bold = false, italic = false },
+      ['n'] = {
+        color = M.get_highlight_fg('CursorLineNr'),
+        bold = false,
+        italic = false,
+      },
+      ['i']  = {
+        color = M.get_highlight_fg('Question'),
+        bold = false,
+        italic = false,
+      },
+      ['v']  = {
+        color = M.get_highlight_fg('Type'),
+        bold = false,
+        italic = false,
+      },
+      ['V']  = {
+        color = M.get_highlight_fg('Type'),
+        bold = false,
+        italic = false,
+      },
+      ['�'] = {
+        color = M.get_highlight_fg('Type'),
+        bold = false,
+        italic = false,
+      },
+      ['s']  = {
+        color = M.get_highlight_fg('Keyword'),
+        bold = false,
+        italic = false,
+      },
+      ['S']  = {
+        color = M.get_highlight_fg('Keyword'),
+        bold = false,
+        italic = false,
+      },
+      ['R']  = {
+        color = M.get_highlight_fg('Title'),
+        bold = false,
+        italic = false,
+      },
+      ['c']  = {
+        color = M.get_highlight_fg('Constant'),
+        bold = false,
+        italic = false,
+      },
     },
   },
 }
 
---- Sets the foreground color value of the `CursorLineNr` highlight groups to
---- `color`.
---- @param color string
-M.set_highlight_and_format = function(color, format)
-  local base_highlight = api.nvim_get_hl_by_name('CursorLineNr', true)
-  -- Should this be defined with these defaults?
-  local base_format = { bold = false, italic = false }
-  local opts = vim.tbl_extend('keep',
-    { foreground = color, bold = format['bold'], italic = format['italic'] },
-  base_highlight, base_format)
-  api.nvim_set_hl(0, 'CursorLineNr', opts)
+--- Set the foreground color, bold text, and italic text
+--- of 'CursorLineNr'.
+--- @param format table
+M.set_format = function(format)
+  local ors = options.highlights.overrides
+  local args = {
+    foreground = format.color,
+    bold = has_overrides and ors.bold or format.bold,
+    italic = has_overrides and ors.italic or format.italic
+  } 
+  api.nvim_set_hl(0, 'CursorLineNr', args)
 end
 
 local function create_autocmd()
@@ -57,9 +84,8 @@ local function create_autocmd()
   api.nvim_create_autocmd('ModeChanged', {
     callback = function()
       local mode = api.nvim_get_mode().mode
-      local color = options.highlights.modes[mode] or options.highlights.modes.n
-      local format = options.formats.modes[mode] or options.formats.modes.n
-      M.set_highlight_and_format(color, format)
+      local format = options.highlights.modes[mode] or options.highlights.modes.n
+      M.set_format(format)
     end,
     group = 'Modicator'
   })
@@ -81,6 +107,9 @@ end
 function M.setup(opts)
   options = vim.tbl_deep_extend('force', options, opts or {})
 
+  --- If the user options have overrides, make sure
+  --- that we use them in M.set_format.
+  has_overrides = opts.highlights.overrides
   if options.show_warnings then
     for _, opt in pairs({ 'cursorline', 'number', 'termguicolors' }) do
       check_option(opt)

--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -24,24 +24,42 @@ local options = {
       ['c']  = M.get_highlight_fg('Constant'),
     },
   },
+  formats = {
+    modes = {
+      ['n']  = { bold = false, italic = false },
+      ['i']  = { bold = false, italic = false },
+      ['v']  = { bold = false, italic = false },
+      ['V']  = { bold = false, italic = false },
+      [''] = { bold = false, italic = false },
+      ['s']  = { bold = false, italic = false },
+      ['S']  = { bold = false, italic = false },
+      ['R']  = { bold = false, italic = false },
+      ['c']  = { bold = false, italic = false },
+    },
+  },
 }
 
 --- Sets the foreground color value of the `CursorLineNr` highlight groups to
 --- `color`.
 --- @param color string
-M.set_highlight = function(color)
+M.set_highlight_and_format = function(color, format)
   local base_highlight = api.nvim_get_hl_by_name('CursorLineNr', true)
-  local opts = vim.tbl_extend('keep', { foreground = color }, base_highlight)
+  -- Should this be defined with these defaults?
+  local base_format = { bold = false, italic = false }
+  local opts = vim.tbl_extend('keep',
+    { foreground = color, bold = format['bold'], italic = format['italic'] },
+  base_highlight, base_format)
   api.nvim_set_hl(0, 'CursorLineNr', opts)
 end
 
 local function create_autocmd()
-  vim.api.nvim_create_augroup('Modicator', {})
-  vim.api.nvim_create_autocmd('ModeChanged', {
+  api.nvim_create_augroup('Modicator', {})
+  api.nvim_create_autocmd('ModeChanged', {
     callback = function()
       local mode = api.nvim_get_mode().mode
       local color = options.highlights.modes[mode] or options.highlights.modes.n
-      M.set_highlight(color)
+      local format = options.formats.modes[mode] or options.formats.modes.n
+      M.set_highlight_and_format(color, format)
     end,
     group = 'Modicator'
   })

--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -12,7 +12,7 @@ end
 local options = {
   show_warnings = true, -- Show warning if any required option is missing
   highlights = {
-    overrides = {
+    defaults = {
       bold = false,
       italic = false
     },
@@ -75,7 +75,7 @@ M.set_highlight = function(format)
     bold = format.bold,
     italic = format.italic
   }
-  args = vim.tbl_extend('keep', options.highlights.overrides, args)
+  args = vim.tbl_extend('keep', options.highlights.defaults, args)
   api.nvim_set_hl(0, 'CursorLineNr', args)
 end
 

--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -70,12 +70,12 @@ local options = {
 --- of 'CursorLineNr'.
 --- @param format table
 M.set_highlight = function(format)
-  local ors = options.highlights.overrides
   local args = {
     foreground = format.color,
-    bold = has_overrides and ors.bold or format.bold,
-    italic = has_overrides and ors.italic or format.italic
-  } 
+    bold = format.bold,
+    italic = format.italic
+  }
+  vim.tbl_extend('force', options.highlights.overrides, args)
   api.nvim_set_hl(0, 'CursorLineNr', args)
 end
 
@@ -107,9 +107,6 @@ end
 function M.setup(opts)
   options = vim.tbl_deep_extend('force', options, opts or {})
 
-  --- If the user options have overrides, make sure
-  --- that we use them in M.set_format.
-  has_overrides = opts.highlights.overrides
   if options.show_warnings then
     for _, opt in pairs({ 'cursorline', 'number', 'termguicolors' }) do
       check_option(opt)

--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -69,7 +69,7 @@ local options = {
 --- Set the foreground color, bold text, and italic text
 --- of 'CursorLineNr'.
 --- @param format table
-M.set_format = function(format)
+M.set_highlight = function(format)
   local ors = options.highlights.overrides
   local args = {
     foreground = format.color,
@@ -85,7 +85,7 @@ local function create_autocmd()
     callback = function()
       local mode = api.nvim_get_mode().mode
       local format = options.highlights.modes[mode] or options.highlights.modes.n
-      M.set_format(format)
+      M.set_highlight(format)
     end,
     group = 'Modicator'
   })

--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -75,7 +75,8 @@ M.set_highlight = function(format)
     bold = format.bold,
     italic = format.italic
   }
-  vim.tbl_extend('force', options.highlights.overrides, args)
+  args = vim.tbl_extend('keep', options.highlights.overrides, args)
+  print(vim.inspect(args))
   api.nvim_set_hl(0, 'CursorLineNr', args)
 end
 

--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -76,7 +76,6 @@ M.set_highlight = function(format)
     italic = format.italic
   }
   args = vim.tbl_extend('keep', options.highlights.overrides, args)
-  print(vim.inspect(args))
   api.nvim_set_hl(0, 'CursorLineNr', args)
 end
 


### PR DESCRIPTION
I added the option to format line numbers with bold or italics. I changed the name of your function `M.set_highlight` to `M.set_highlight_and_format` with a new parameter `format`.

Note: I haven't seen the syntax `---@param color string` before, so you might have to update that for the new `format` parameter.