### PR TITLE
[Fix] Fixed colorscheme autocmd disregarding lualine colors

### DIFF
--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -107,15 +107,21 @@ M.set_cursor_line_highlight = function(hl_name)
   api.nvim_set_hl(0, 'CursorLineNr', hl)
 end
 
+local function update_mode()
+  local mode = api.nvim_get_mode().mode
+  local mode_name = mode_name_from_mode(mode)
+
+  M.set_cursor_line_highlight(mode_name .. 'Mode')
+end
+
 local function create_autocmds()
   local augroup = api.nvim_create_augroup('Modicator', {})
+  api.nvim_create_autocmd('VimEnter', {
+    callback = update_mode,
+    group = augroup,
+  })
   api.nvim_create_autocmd('ModeChanged', {
-    callback = function()
-      local mode = api.nvim_get_mode().mode
-      local mode_name = mode_name_from_mode(mode)
-
-      M.set_cursor_line_highlight(mode_name .. 'Mode')
-    end,
+    callback = update_mode,
     group = augroup,
   })
   api.nvim_create_autocmd('Colorscheme', {

--- a/lua/modicator/init.lua
+++ b/lua/modicator/init.lua
@@ -24,6 +24,11 @@ M.get_highlight = function(hl_name)
   return api.nvim_get_hl(0, { name = hl_name, link = false })
 end
 
+local function lualine_is_loaded()
+  local ok, _ = pcall(require, 'lualine')
+  return ok
+end
+
 local function fallback_hl_from_mode(mode)
   local hls = {
     Normal = 'CursorLineNr',
@@ -68,6 +73,14 @@ local function set_fallback_highlight_groups()
   end
 end
 
+local function set_highlight_groups()
+  if lualine_is_loaded() and options.integration.lualine.enabled then
+    require('integration.lualine').use_lualine_mode_highlights()
+  else
+    set_fallback_highlight_groups()
+  end
+end
+
 local function mode_name_from_mode(mode)
   local mode_names = {
     ['n']  = 'Normal',
@@ -106,7 +119,7 @@ local function create_autocmds()
     group = augroup,
   })
   api.nvim_create_autocmd('Colorscheme', {
-    callback = set_fallback_highlight_groups,
+    callback = set_highlight_groups,
     group = augroup,
   })
 end
@@ -133,11 +146,6 @@ local function check_deprecated_config(opts)
   end
 end
 
-local function lualine_is_loaded()
-  local ok, _ = pcall(require, 'lualine')
-  return ok
-end
-
 function M.setup(opts)
   options = vim.tbl_deep_extend('force', options, opts or {})
 
@@ -148,11 +156,7 @@ function M.setup(opts)
     check_deprecated_config(options)
   end
 
-  if lualine_is_loaded() and options.integration.lualine.enabled then
-    require('integration.lualine').use_lualine_mode_highlights()
-  else
-    set_fallback_highlight_groups()
-  end
+  set_highlight_groups()
 
   vim.api.nvim_set_hl(0, 'CursorLineNr', { link = 'NormalMode' })
 


### PR DESCRIPTION
Fixes an issue where if the colorscheme is changed after the initialization, it uses fallback colors without ever considering lualine colors.

Changes:
- Moved `lualine_is_loaded` to the top in order to make it usable in autocmd
- Added `set_highlight_groups` to use in autocmd and the setup function

EDIT: I just noticed that the color state doesn't update right away, so I added a `VimEnter` autocmd to fix that.