### PR TITLE
feat!: use the theme from lualine config (a string for filename or a table)

### DIFF
--- a/lua/modicator/integration/lualine/init.lua
+++ b/lua/modicator/integration/lualine/init.lua
@@ -60,9 +60,14 @@ end
 --- @return table?
 local function get_lualine_theme()
   local loader = require('lualine.utils.loader')
-  local ok, theme = pcall(loader.load_theme, vim.g.colors_name)
-  if ok and theme then
-    return theme
+  local lualine_theme = require('lualine').get_config().options.theme
+  if (type(lualine_theme) == 'table') then
+    return lualine_theme
+  else
+    local ok, theme = pcall(loader.load_theme, lualine_theme)
+    if ok and theme then
+      return theme
+    end
   end
 end
 


### PR DESCRIPTION
Adds support to
- use a [lualine theme](https://github.com/nvim-lualine/lualine.nvim/blob/master/THEMES.md) that differs from the main theme (a string pointing to a file.lua)
- use a [customized theme](https://github.com/nvim-lualine/lualine.nvim?tab=readme-ov-file#customizing-themes) (a table of `<mode>={ a={}, b={}, c={} }`)